### PR TITLE
Use trackBy function to prevent rerender of unchanged notifications

### DIFF
--- a/TestErpApp/ClientApp/src/app/home/home.component.html
+++ b/TestErpApp/ClientApp/src/app/home/home.component.html
@@ -13,7 +13,7 @@
 <div class="box">
   <div class="notifications">
     <h2>Notificaties</h2>
-    <div *ngFor="let notification of notifications">
+    <div *ngFor="let notification of notifications; trackBy: notificationIdentifier ">
       <pre>{{ notification | json }}</pre>
       <button *ngIf="notification.dataUrl" class="btn btn-primary" (click)="GetFile(notification)">Bestand ophalen</button>
     </div>

--- a/TestErpApp/ClientApp/src/app/home/home.component.ts
+++ b/TestErpApp/ClientApp/src/app/home/home.component.ts
@@ -28,6 +28,11 @@ export class HomeComponent {
   public saveKey() {
     this.http.post(this.baseUrl + 'key', { key: this.key }).subscribe(() => { });
   }
+
+  public notificationIdentifier(_index: number, item: NotificationModel) {
+    return item.dataUrl;
+  }
+
   private IsJson(value: string) : boolean{
     try {
       JSON.parse(value);


### PR DESCRIPTION
Using the trackBy function prevents rerender of unchanged notifications.
This enables users to copy data from notification in the user interface.

I picked the dataUrl as unique identifier, the dataUrl will always be unique in production scenario's as it contains nearly all different properties.