### PR TITLE
deps: Update TargetFramework to dotnet 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .vs
-.vscode
 obj
 bin
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["ms-dotnettools.csharp"]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Api",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build testerp app",
+      "program": "${workspaceFolder}/TestErpApp/bin/Debug/net8.0/TestErpApp.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/TestErpApp",
+      "externalConsole": true,
+      "stopAtEntry": false,
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build testerp app",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/TestErpApp/TestErpApp.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/TestErpApp/Controllers/KeyController.cs
+++ b/TestErpApp/Controllers/KeyController.cs
@@ -4,13 +4,9 @@ namespace TestErpApp.Controllers
 {
     [ApiController]
     [Route("[controller]")]
-    public class KeyController : ControllerBase
+    public class KeyController(IServiceProvider services) : ControllerBase
     {
-        private readonly IServiceProvider _services;
-        public KeyController(IServiceProvider services)
-        {
-            _services = services;
-        }
+        private readonly IServiceProvider _services = services;
 
         [HttpGet]
         public KeyModel Get()

--- a/TestErpApp/Controllers/KeyController.cs
+++ b/TestErpApp/Controllers/KeyController.cs
@@ -1,35 +1,32 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿namespace TestErpApp.Controllers;
 
-namespace TestErpApp.Controllers
+[ApiController]
+[Route("[controller]")]
+public class KeyController(IServiceProvider services) : ControllerBase
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class KeyController(IServiceProvider services) : ControllerBase
+    private readonly IServiceProvider _services = services;
+
+    [HttpGet]
+    public KeyModel Get()
     {
-        private readonly IServiceProvider _services = services;
-
-        [HttpGet]
-        public KeyModel Get()
+        var store = _services.GetService<KeyStore>();
+        return new KeyModel
         {
-            var store = _services.GetService<KeyStore>();
-            return new KeyModel
-            {
-                Key = store.Key
-            };
-        }
-
-        [HttpPost]
-        public ActionResult Set([FromBody] KeyModel key)
-        {
-            var store = _services.GetService<KeyStore>();
-            store.Key = key.Key;
-
-            return new OkResult();
-        }
+            Key = store?.Key ?? string.Empty
+        };
     }
 
-    public class KeyModel
+    [HttpPost]
+    public ActionResult Set([FromBody] KeyModel key)
     {
-        public string Key { get; set; }
+        var store = _services.GetService<KeyStore>();
+        store!.Key = key.Key;
+
+        return new OkResult();
     }
+}
+
+public class KeyModel
+{
+    public required string Key { get; set; }
 }

--- a/TestErpApp/Controllers/NotificationsController.cs
+++ b/TestErpApp/Controllers/NotificationsController.cs
@@ -4,13 +4,9 @@ namespace TestErpApp.Controllers
 {
     [ApiController]
     [Route("[controller]")]
-    public class NotificationsController : ControllerBase
+    public class NotificationsController(IServiceProvider services) : ControllerBase
     {
-        private readonly IServiceProvider _services;
-        public NotificationsController(IServiceProvider services)
-        {
-            _services = services;
-        }
+        private readonly IServiceProvider _services = services;
 
         [HttpGet]
         public IEnumerable<NotificationModel> Get()
@@ -28,7 +24,7 @@ namespace TestErpApp.Controllers
         }
 
         [HttpPost]
-        public ActionResult Notify([FromBody]NotificationModel content)
+        public ActionResult Notify([FromBody] NotificationModel content)
         {
             var store = _services.GetService<NotificationStore>();
             store.Add(content);

--- a/TestErpApp/Controllers/NotificationsController.cs
+++ b/TestErpApp/Controllers/NotificationsController.cs
@@ -1,44 +1,43 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿namespace TestErpApp.Controllers;
 
-namespace TestErpApp.Controllers
+[ApiController]
+[Route("[controller]")]
+public class NotificationsController(IServiceProvider services) : ControllerBase
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class NotificationsController(IServiceProvider services) : ControllerBase
+    private readonly IServiceProvider _services = services;
+
+    [HttpGet]
+    public IEnumerable<NotificationModel> Get()
     {
-        private readonly IServiceProvider _services = services;
-
-        [HttpGet]
-        public IEnumerable<NotificationModel> Get()
-        {
-            var store = _services.GetService<NotificationStore>();
-            return store.Get();
-        }
-
-        [HttpDelete]
-        public ActionResult Delete()
-        {
-            var store = _services.GetService<NotificationStore>();
-            store.Clear();
-            return new OkResult();
-        }
-
-        [HttpPost]
-        public ActionResult Notify([FromBody] NotificationModel content)
-        {
-            var store = _services.GetService<NotificationStore>();
-            store.Add(content);
-            return new OkResult();
-        }
+        var store = _services.GetService<NotificationStore>();
+        return store?.Get() ?? [];
     }
 
-    public class NotificationModel
+    [HttpDelete]
+    public ActionResult Delete()
     {
-        public Guid? FileId { get; set; }
-        public string? FileVersion { get; set; }
-        public string? ApplicationName { get; set; }
-        public Uri? DataUrl { get; set; }
-        public string? Token { get; set; }
-        public Dictionary<string, string>? customProperties { get; set; }
+        var store = _services.GetService<NotificationStore>();
+        store?.Clear();
+        return new OkResult();
     }
+
+    [HttpPost]
+    public ActionResult Notify([FromBody] NotificationModel content)
+    {
+        var store = _services.GetService<NotificationStore>();
+        store?.Add(content);
+        return new OkResult();
+    }
+}
+
+public class NotificationModel
+{
+    public Guid? FileId { get; set; }
+    public string? FileVersion { get; set; }
+    public string? ApplicationName { get; set; }
+    public Uri? DataUrl { get; set; }
+    public string? Token { get; set; }
+#pragma warning disable IDE1006 // Naming Styles, due to external API
+    public Dictionary<string, string>? customProperties { get; set; }
+#pragma warning restore IDE1006 // Naming Styles
 }

--- a/TestErpApp/KeyStore.cs
+++ b/TestErpApp/KeyStore.cs
@@ -1,16 +1,15 @@
-﻿namespace TestErpApp
+﻿namespace TestErpApp;
+
+public class KeyStore
 {
-    public class KeyStore
+    private string _key = string.Empty;
+
+    public string Key
     {
-        private string _key = string.Empty;
-        
-        public string Key
+        get => _key;
+        set
         {
-            get => _key;
-            set 
-            {
-                _key = value;
-            } 
+            _key = value;
         }
     }
 }

--- a/TestErpApp/NotificationStore.cs
+++ b/TestErpApp/NotificationStore.cs
@@ -1,23 +1,20 @@
-﻿using TestErpApp.Controllers;
+﻿namespace TestErpApp;
 
-namespace TestErpApp
+public class NotificationStore
 {
-    public class NotificationStore
+    private readonly List<NotificationModel> _notifications = [];
+    public void Add(NotificationModel notification)
     {
-        private List<NotificationModel> _notifications = new List<NotificationModel>();
-        public void Add(NotificationModel notification)
-        {
-            _notifications.Add(notification);
-        }
+        _notifications.Add(notification);
+    }
 
-        public void Clear()
-        {
-            _notifications.Clear();
-        }
+    public void Clear()
+    {
+        _notifications.Clear();
+    }
 
-        public IEnumerable<NotificationModel> Get()
-        {
-            return _notifications;
-        }
+    public IEnumerable<NotificationModel> Get()
+    {
+        return _notifications;
     }
 }

--- a/TestErpApp/Pages/Error.cshtml.cs
+++ b/TestErpApp/Pages/Error.cshtml.cs
@@ -1,21 +1,16 @@
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using System.Diagnostics;
+namespace TestErpApp.Pages;
 
-namespace TestErpApp.Pages
+[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+public class ErrorModel(ILogger<ErrorModel> logger) : PageModel
 {
-    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
-    public class ErrorModel(ILogger<ErrorModel> logger) : PageModel
+    private readonly ILogger<ErrorModel> _logger = logger;
+
+    public string? RequestId { get; set; }
+
+    public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+    public void OnGet()
     {
-        private readonly ILogger<ErrorModel> _logger = logger;
-
-        public string? RequestId { get; set; }
-
-        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
-
-        public void OnGet()
-        {
-            RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
-        }
+        RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
     }
 }

--- a/TestErpApp/Pages/Error.cshtml.cs
+++ b/TestErpApp/Pages/Error.cshtml.cs
@@ -5,14 +5,9 @@ using System.Diagnostics;
 namespace TestErpApp.Pages
 {
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
-    public class ErrorModel : PageModel
+    public class ErrorModel(ILogger<ErrorModel> logger) : PageModel
     {
-        private readonly ILogger<ErrorModel> _logger;
-
-        public ErrorModel(ILogger<ErrorModel> logger)
-        {
-            _logger = logger;
-        }
+        private readonly ILogger<ErrorModel> _logger = logger;
 
         public string? RequestId { get; set; }
 

--- a/TestErpApp/Program.cs
+++ b/TestErpApp/Program.cs
@@ -1,5 +1,3 @@
-using TestErpApp;
-
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.

--- a/TestErpApp/TestErpApp.csproj
+++ b/TestErpApp/TestErpApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <SpaRoot>ClientApp\</SpaRoot>
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TestErpApp/usings.cs
+++ b/TestErpApp/usings.cs
@@ -1,0 +1,5 @@
+global using TestErpApp.Controllers;
+global using Microsoft.AspNetCore.Mvc;
+global using Microsoft.AspNetCore.Mvc.RazorPages;
+global using System.Diagnostics;
+global using TestErpApp;


### PR DESCRIPTION
This pull request includes the following changes:

- Update the TargetFramework to net8.0

- Refactor the constructors of the `KeyController`, `NotificationsController`, and `ErrorModel` classes to use dependency injection for the `IServiceProvider` and `ILogger` dependencies. This improves code readability and maintainability.

- Refactor code to use global usings. This way the usings are centered globally, removing clutter on the actual files

- [Primary constructors](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/primary-constructors)

- other 'Problems' pointed out by vscode (nullability of properties and naming styles)

- Adds vscode settings folder. This is for people using vscode to have a setup for their IDE

