### PR TITLE
fix: remove extra dashes from npm run build command

### DIFF
--- a/TestErpApp/TestErpApp.csproj
+++ b/TestErpApp/TestErpApp.csproj
@@ -34,7 +34,7 @@
   <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
     <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
     <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build -- --prod" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build --prod" />
 
     <!-- Include the newly-built files in the publish output -->
     <ItemGroup>


### PR DESCRIPTION
Extra dashes were preventing a successful publish.